### PR TITLE
minor: build target to nodenext

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,5 @@ name: CI
 on: push
 
 jobs:
-  build:
-    uses: jill64/workflows/.github/workflows/build.yml@main
   coverage:
     uses: jill64/workflows/.github/workflows/coverage.yml@main

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jill64/async-observer",
-  "version": "1.0.15",
+  "version": "1.1.0",
   "type": "module",
   "description": "Make Promise state observable as a string",
   "main": "dist/index.js",

--- a/rsac.yml
+++ b/rsac.yml
@@ -2,5 +2,4 @@ branch-protection:
   main:
     required_status_checks:
       contexts:
-        - build / build
         - coverage / coverage

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -1,5 +1,5 @@
 import { writable } from 'svelte/store'
-import type { PromiseStatus } from './PromiseStatus'
+import type { PromiseStatus } from './PromiseStatus.js'
 
 export const observable = (options?: {
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "target": "ESNext"
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
   },
   "include": ["./src/*"]
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Simplified our Continuous Integration (CI) process by removing the redundant `build` job. This change streamlines our development workflow, making it more efficient.
- Refactor: Updated the import statement in our code to correctly reference the `PromiseStatus.js` file. This change ensures the correct file is used, improving the reliability of our software.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->